### PR TITLE
Fixed semester table bug

### DIFF
--- a/src/components/SemesterTable.tsx
+++ b/src/components/SemesterTable.tsx
@@ -32,15 +32,17 @@ export const SemesterTable = (): JSX.Element =>
                         </thead>
                         <tbody {...prov.droppableProps} ref={prov.innerRef}>
                             <tr>
-                                <ListGroup>
-                                    {
-                                        value.map((e, i) =>
-                                            <ListGroup.Item key={i}>
-                                                <Course name={`${e.name}-${e.section}`} ind={i}/>
-                                            </ListGroup.Item>
-                                        )
-                                    }
-                                </ListGroup>
+                                <td>
+                                    <ListGroup>
+                                        {
+                                            value.map((e, i) =>
+                                                <ListGroup.Item key={i}>
+                                                    <Course name={`${e.name}-${e.section}`} ind={i}/>
+                                                </ListGroup.Item>
+                                            )
+                                        }
+                                    </ListGroup>
+                                </td>
                             </tr>
                         </tbody>
                     </Table>


### PR DESCRIPTION
Fixed <div> cannot be child of <tr> error by placing <td> inside of <tr> then <div> being a child of <td> instead of <tr>